### PR TITLE
PR: Add ability to edit card tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+.vscode/

--- a/content.php
+++ b/content.php
@@ -70,7 +70,7 @@ if (is_home() or is_search() or is_category()) :
 	    <form method="post" style="height:90%">
 		    <input name="title" type="hidden" id="formtitle<?php echo get_the_ID();?>" value="<?php the_title(); ?>">
 		    <textarea name="content" id="formcontent<?php echo get_the_ID();?>" style="height:85%; font-size:small"><?php echo get_the_content(); ?></textarea>
-				<input name="tags"  id="tags<?php echo get_the_ID();?>" placeholder="tags, comma-separated" style="font-size:small" value="<?php wz_echo_post_tags(get_the_ID());?>">
+				<?php if(get_theme_mod('checkbox_tags') == true) echo wz_build_tag_edit(get_the_ID());?>
 		    <input type="hidden" name="action" value="update">
         <input name="s" id="s" type="hidden" value="<?php echo $_POST['s']; ?>">
 		    <input type="submit" style="font-size:10px" value="Update"> &nbsp;

--- a/content.php
+++ b/content.php
@@ -70,6 +70,7 @@ if (is_home() or is_search() or is_category()) :
 	    <form method="post" style="height:90%">
 		    <input name="title" type="hidden" id="formtitle<?php echo get_the_ID();?>" value="<?php the_title(); ?>">
 		    <textarea name="content" id="formcontent<?php echo get_the_ID();?>" style="height:85%; font-size:small"><?php echo get_the_content(); ?></textarea>
+				<input name="tags"  id="tags<?php echo get_the_ID();?>" placeholder="tags, comma-separated" style="font-size:small" value="<?php wz_echo_post_tags(get_the_ID());?>">
 		    <input type="hidden" name="action" value="update">
         <input name="s" id="s" type="hidden" value="<?php echo $_POST['s']; ?>">
 		    <input type="submit" style="font-size:10px" value="Update"> &nbsp;

--- a/functions.php
+++ b/functions.php
@@ -922,7 +922,7 @@ function do_quick_update($wpdb){
   $content = str_replace("[=](http","[source](http",$content);
   $content = str_replace("[-](http","[link](http",$content);
 
-
+  $tags =  $_POST['tags'];
 
   /* If slug exists update page and redirect */
 
@@ -939,7 +939,8 @@ function do_quick_update($wpdb){
     'slug'           => $slug,
     'post_content'   => $content,
     'post_title'     => $title,
-    'post_status'    => 'publish'
+    'post_status'    => 'publish',
+    'tags_input'    =>  $tags
     );
    wp_insert_post( $my_post, true );
   } else {
@@ -947,7 +948,8 @@ function do_quick_update($wpdb){
     'slug'           => $slug,
     'post_content'   => $content,
     'post_title'     => "Untitled: ".uniqid(),
-    'post_status'    => 'publish'
+    'post_status'    => 'publish',
+    'tags_input'    =>  $tags
     );
    wp_insert_post( $my_post, true );
   }

--- a/functions.php
+++ b/functions.php
@@ -930,7 +930,8 @@ function do_quick_update($wpdb){
 
     $my_post = array(
         'ID'           => $postid,
-        'post_content'   => $content
+        'post_content'   => $content,
+        'tags_input'    =>  $tags
     );
     wp_update_post( $my_post );
   } elseif ($title != '') {
@@ -1173,3 +1174,16 @@ function posts_where_statement( $where ) {
 	return $where;
 
 }
+
+function wz_echo_post_tags( $i ) {
+    $tagstr = '';
+    $posttags = get_the_tags($i);
+    if ($posttags) {
+      foreach($posttags as $tag) {
+        $tagstr = $tagstr . $tag->name . ', '; 
+      }
+      $tagstr = substr($tagstr , 0, -2);
+    } 
+    echo $tagstr;
+}
+

--- a/functions.php
+++ b/functions.php
@@ -1175,15 +1175,52 @@ function posts_where_statement( $where ) {
 
 }
 
-function wz_echo_post_tags( $i ) {
-    $tagstr = '';
-    $posttags = get_the_tags($i);
+function wz_build_tagstring($id){
+  $tagstr = '';
+    $posttags = get_the_tags($id);
     if ($posttags) {
       foreach($posttags as $tag) {
         $tagstr = $tagstr . $tag->name . ', '; 
       }
       $tagstr = substr($tagstr , 0, -2);
     } 
-    echo $tagstr;
+    return $tagstr;
 }
+
+/*
+function wz_echo_post_tags( $id ) {
+    //echo wz_build_tagstring($id);
+}
+*/
+// add theme customisation controls for tag functionality
+function wz_register_theme_customizer( $wp_customize ) {
+    $wp_customize->add_section('wz_tags_section', array(
+        'title'    => __('Tag Functions', 'Wikity-Zero'),
+        'description' => '',
+        'priority' => 500,
+    ));
+
+    $wp_customize->add_setting('theme_mods_wikity-zero[checkbox_tags]', array(
+    //$wp_customize->add_setting('checkbox_tags', array(
+        'capability' => 'edit_theme_options',
+        'type'       => 'option',
+    ));
+ 
+    $wp_customize->add_control('display_tag_options', array(
+        'settings' => 'theme_mods_wikity-zero[checkbox_tags]',
+        //'settings' => 'checkbox_tags',
+        'label'    => __('Display Tag Options'),
+        'section'  => 'wz_tags_section',
+        'type'     => 'checkbox',
+    ));
+}
+add_action( 'customize_register', 'wz_register_theme_customizer' ); 
+
+
+function wz_build_tag_edit($id){
+  $tagstring = ($id == null) ? '' : wz_build_tagstring($id);
+  $result = '<input name="tags"  id="tags' . $id . '" placeholder="tags, comma-separated" style="font-size:small" value="' .  $tagstring . '">';
+  return $result;
+}
+
 

--- a/index.php
+++ b/index.php
@@ -274,7 +274,7 @@ get_header();
                 var simplemde = new SimpleMDE({ element: $("#formcontent")[0] });
                 simplemde.options.insertTexts.image= ["![](http://image_url", ")"];
               </script>
-
+              <input name="tags" id="tags"  placeholder="tags, comma-separated" >
       		    <input type="hidden" name="action" value="update">
       		    <input name="after" type="hidden" value="<?php echo $after; ?>">
 

--- a/index.php
+++ b/index.php
@@ -274,7 +274,9 @@ get_header();
                 var simplemde = new SimpleMDE({ element: $("#formcontent")[0] });
                 simplemde.options.insertTexts.image= ["![](http://image_url", ")"];
               </script>
-              <input name="tags" id="tags"  placeholder="tags, comma-separated" >
+              <?php 
+              if(get_theme_mod('checkbox_tags') == true) echo '<input name="tags" id="tags"  placeholder="tags, comma-separated" >';   
+              ?>
       		    <input type="hidden" name="action" value="update">
       		    <input name="after" type="hidden" value="<?php echo $after; ?>">
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -338,6 +338,7 @@ function updateUrlList(val, op) {
 function sendToBigEditor(id, op){
 	simplemde.value($("#formcontent"+id).val());
 	$("#formtitle").val($("#formtitle"+id).val());
+	$("#tags").val($("#tags"+id).val());
 	$("html, body").animate({ scrollTop: 0 }, "slow");
 	$('#formcontent').addClass("attention");  
 }


### PR DESCRIPTION
Hi Mike

While practicing with Wikity, I felt a strong need to be able to tag cards as a way of organising them.

This pull request adds some basic functionality to display and edit the native WordPress tags for a card. Offered in case it is of interest!

regards

Julian