### PR TITLE
After forking remote card, redirect to new card on own site (bugfix) fixes #7

### DIFF
--- a/index.php
+++ b/index.php
@@ -205,6 +205,7 @@ if (strlen($_GET['fedwiki']) > 0){
 // GET CARD
 
 if (strlen($_GET['slug']) > 0){
+  $slug = $_GET['slug'];
   define('IFRAME_REQUEST' , true);
   /** WordPress Administration Bootstrap */
   getCard($_GET['site'], $_GET['slug'], $wpdb);


### PR DESCRIPTION
Fixes #7 

$slug was not being populated from GET['slug'] before being used in the redirect